### PR TITLE
Move favorite filtering from dashboard render to separate function. 

### DIFF
--- a/src/components/dashboard/dashboard-component.js
+++ b/src/components/dashboard/dashboard-component.js
@@ -36,8 +36,7 @@ function Dashboard({ userName, setLoginStatus }) {
     const id = event.target.id
     let updatedFavorites;
     userFavorites.includes(id) ?
-      updatedFavorites = userFavorites.filter(favorite => favorite !== id)
-      :
+      updatedFavorites = userFavorites.filter(favorite => favorite !== id) :
       updatedFavorites = [...userFavorites, id]
 
     currentUser.updateFavorites(updatedFavorites)
@@ -47,6 +46,14 @@ function Dashboard({ userName, setLoginStatus }) {
   const selectCurrency = (event) => {
     event.preventDefault()
     setCurrency(event.target.value)
+  }
+
+  const filterFavorites = (favorited) => {
+    let filteredCoins;
+    favorited === true ?
+      filteredCoins = allCoins.filter(coin => userFavorites.includes(coin.id)) :
+      filteredCoins = allCoins.filter(coin => !userFavorites.includes(coin.id))
+    return filteredCoins
   }
 
   return (
@@ -68,9 +75,7 @@ function Dashboard({ userName, setLoginStatus }) {
                   favorited='favorited-coin'
                   currency={currency}
                   addFavorite={event => addFavorite(event)}
-                  coins={
-                    allCoins.filter(coin => userFavorites.includes(coin.id))
-                  }
+                  coins={filterFavorites(true)}
                   key='favoriteCoins'
                 />
               </h1>
@@ -80,9 +85,7 @@ function Dashboard({ userName, setLoginStatus }) {
                   favorited='unfavorited-coin'
                   currency={currency}
                   addFavorite={event => addFavorite(event)}
-                    coins={
-                      allCoins.filter(coin => !userFavorites.includes(coin.id))
-                    }
+                    coins={filterFavorites(false)}
                     key='allCoins'
                   />
               </h1>


### PR DESCRIPTION
#### What does  this PR do?

Removes the favorite filtering logic from the dashboard return statement. Cleans up existing ternary in dashboard component for readability.

#### Where should the reviewer start?

Review `filterFavorites` function added to `dashboard.js`, and where it is called in the return statement.

#### Is this a bug fix or a feature?

Feature.

#### How should this be manually tested?

In browser, ensure that favorites/all coins lists are being rendered correctly.